### PR TITLE
Fix leftover merge markers in LeViT MiniViT script

### DIFF
--- a/LeViT.py
+++ b/LeViT.py
@@ -46,11 +46,7 @@ class MiniViT(nn.Module):
     """
     def __init__(self, *, image_size=16, patch_size=2, num_classes=10,
                  dim=20, depth=3, heads=2, mlp_dim=28, channels=1,
-<<<<<<< HEAD
-                 attn_dropout=0.10, mlp_dropout=0.1, use_mean_pool=True,
-=======
                  attn_dropout=0.10, mlp_dropout=0.10, use_mean_pool=True,
->>>>>>> main
                  augment_roll=True):
         super().__init__()
         assert image_size % patch_size == 0, "image_size must be divisible by patch_size"


### PR DESCRIPTION
## Summary
- resolve git merge markers in `LeViT.py`

## Testing
- `python -m py_compile LeViT.py`
- `python3 LeViT.py` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68ba46e85da88321b3e8405f54eb1b1f